### PR TITLE
refactor: Replace variadic listen method

### DIFF
--- a/Chapter 5/building-a-new-validator-compiler.cjs
+++ b/Chapter 5/building-a-new-validator-compiler.cjs
@@ -33,7 +33,7 @@ app.get('/success', {
   }
 })
 
-app.listen(8080)
+app.listen({ port: 8080 })
 
 async function echo (request, reply) {
   return {

--- a/Chapter 5/configuring-the-default-ajv-validator-compiler.cjs
+++ b/Chapter 5/configuring-the-default-ajv-validator-compiler.cjs
@@ -32,7 +32,7 @@ app.get('/search', {
   }
 })
 
-app.listen(8080)
+app.listen({ port: 8080 })
 
 async function echo (request, reply) {
   return {

--- a/Chapter 5/custom-options.cjs
+++ b/Chapter 5/custom-options.cjs
@@ -35,7 +35,7 @@ app.get('/search', {
   }
 })
 
-app.listen(8080)
+app.listen({ port: 8080 })
 
 async function echo (request, reply) {
   return {

--- a/Chapter 5/customizing-the-schema-validator-compiler.cjs
+++ b/Chapter 5/customizing-the-schema-validator-compiler.cjs
@@ -22,7 +22,7 @@ app.register(async function plugin (instance, opts) {
   })
 })
 
-app.listen(8080)
+app.listen({ port: 8080 })
 
 async function echo (request, reply) {
   return {

--- a/Chapter 5/customizing-the-validator-compiler.cjs
+++ b/Chapter 5/customizing-the-validator-compiler.cjs
@@ -25,4 +25,4 @@ app.get('/attach-validation', {
   }
 })
 
-app.listen(8080)
+app.listen({ port: 8080 })

--- a/Chapter 5/managing-the-serializer-compiler.cjs
+++ b/Chapter 5/managing-the-serializer-compiler.cjs
@@ -37,4 +37,4 @@ app.get('/serializer-compiler', {
   reply.send({ hello: 'world' })
 })
 
-app.listen(8080)
+app.listen({ port: 8080 })

--- a/Chapter 5/retrieving-your-schemas.cjs
+++ b/Chapter 5/retrieving-your-schemas.cjs
@@ -35,4 +35,4 @@ app.register(async (instance, opts) => {
   })
 }, { prefix: '/child' })
 
-app.listen(8080)
+app.listen({ port: 8080 })

--- a/Chapter 5/reusing-json-schemas.cjs
+++ b/Chapter 5/reusing-json-schemas.cjs
@@ -52,7 +52,7 @@ app.post('/schema-ref', {
   }
 })
 
-app.listen(8080)
+app.listen({ port: 8080 })
 
 async function echo (request, reply) {
   return {

--- a/Chapter 5/the-reply-serializer.cjs
+++ b/Chapter 5/the-reply-serializer.cjs
@@ -14,4 +14,4 @@ app.get('/reply-serializer', function handler (request, reply) {
     .send({ hello: 'world' })
 })
 
-app.listen(8080)
+app.listen({ port: 8080 })

--- a/Chapter 5/the-serializer-compiler.cjs
+++ b/Chapter 5/the-serializer-compiler.cjs
@@ -22,4 +22,4 @@ app.post('/filter', {
   }
 })
 
-app.listen(8080)
+app.listen({ port: 8080 })

--- a/Chapter 5/the-validation-error-formatter.cjs
+++ b/Chapter 5/the-validation-error-formatter.cjs
@@ -15,14 +15,17 @@ app.get('/custom-route-error-formatter', {
   }
 })
 app.register(function plugin (instance, opts, next) {
-  instance.get('/custom-error-formatter', echo)
+  instance.get('/custom-error-formatter', {
+    handler: echo,
+    schema: { query: { myId: { type: 'integer' } } }
+  })
   instance.setSchemaErrorFormatter(function (errors, httpPart) { // [3]
     return new Error('plugin error formatter')
   })
   next()
 })
 
-app.listen(8080)
+app.listen({ port: 8080 })
 
 async function echo (request, reply) {
   return {

--- a/Chapter 5/the-validation-error.cjs
+++ b/Chapter 5/the-validation-error.cjs
@@ -3,6 +3,7 @@
 const fastify = require('fastify')
 
 const app = fastify({
+  logger: true,
   ajv: {
     customOptions: {
       coerceTypes: 'array',
@@ -30,7 +31,7 @@ app.setErrorHandler(function (error, request, reply) {
   }
 })
 
-app.listen(8080)
+app.listen({ port: 8080 })
 
 async function echo (request, reply) {
   return {

--- a/Chapter 5/the-validator-compiler.cjs
+++ b/Chapter 5/the-validator-compiler.cjs
@@ -68,4 +68,4 @@ app.post('/echo/:myInteger', {
   reply.send(request.body)
 })
 
-app.listen(8080)
+app.listen({ port: 8080 })

--- a/Chapter 5/understanding-the-ajv-configuration.cjs
+++ b/Chapter 5/understanding-the-ajv-configuration.cjs
@@ -32,7 +32,7 @@ app.post('/config-in-action', {
   }
 })
 
-app.listen(8080)
+app.listen({ port: 8080 })
 
 // curl --location --request POST 'http://localhost:8080/config-in-action' \
 // --header 'Content-Type: application/json' \


### PR DESCRIPTION
This PR introduces some minor improvements:
- Replaces the deprecated variadic listen method to avoid the warning:
> FastifyDeprecation: Variadic listen method is deprecated. Please use ".listen(optionsObject)" instead. The variadic signature will be removed in `fastify@5`.
- Enables the logger in `the-validation-error.cjs` file to output any logs
- Adds a schema in `the-validation-error-formatter.cjs` file to be able to trigger the SchemaErrorFormatter on `/custom-error-formatter` endpoint.