### PR TITLE
fix: updatedAt -> modifiedAt

### DIFF
--- a/Chapter 8/routes/todos/files/routes.js
+++ b/Chapter 8/routes/todos/files/routes.js
@@ -96,7 +96,7 @@ module.exports = async function fileTodoRoutes (fastify, _opts) {
       return cursor.pipe(csvStringify({
         quoted_string: true,
         header: true,
-        columns: ['title', 'done', 'createdAt', 'updatedAt', 'id'],
+        columns: ['title', 'done', 'createdAt', 'modifiedAt', 'id'],
         cast: {
           boolean: (value) => value ? 'true' : 'false',
           date: (value) => value.toISOString()


### PR DESCRIPTION
# Proposed changes

This pr fixes the invalid column name for the CSV parser in Chapter 8. The author is using `updatedAt` property. However, throughout the chapter, we only use the `modifiedAt` field