### PR TITLE
Fix: Use 'user' object for access 'isAdmin'

### DIFF
--- a/Chapter 3/managing-the-routes-scope-nested.cjs
+++ b/Chapter 3/managing-the-routes-scope-nested.cjs
@@ -26,7 +26,7 @@ async function rootChildPlugin (plugin) {
 }
 async function childPlugin (plugin) {
   plugin.addHook('onRequest', function adminHook (request, reply, done) {
-    if (!request.isAdmin) {
+    if (!request.user.isAdmin) {
       done(new Error('You are not an admin'))
       return
     }


### PR DESCRIPTION
Hi, I noticed that in the exercise on nested routes, the lowest level scope is missing the 'user' object to access 'isAdmin' and check the condition.