### PR TITLE
fix: startArgs in flci.build

### DIFF
--- a/Chapter 10/test/helper.js
+++ b/Chapter 10/test/helper.js
@@ -4,7 +4,7 @@
 // between our tests.
 const fcli = require('fastify-cli/helper')
 
-const startArgs = '-l silent --options app.js'
+const startArgs = ['-l silent --options app.js']
 
 const defaultEnv = {
   NODE_ENV: 'test',


### PR DESCRIPTION
 startArgs in flci.build needs to be an array of strings otherwise config is not taken

passing a string as startArgs in fcli.build doesn't allow to edit the config of application